### PR TITLE
fix(cli): resolve template paths in bundled CLI

### DIFF
--- a/.changeset/fix-template-paths.md
+++ b/.changeset/fix-template-paths.md
@@ -1,0 +1,7 @@
+---
+"@baton-dx/cli": patch
+---
+
+Fix template path resolution in bundled CLI for `source create` and `profile create` commands
+
+Both commands referenced templates via `src/templates/` which doesn't exist in the published package. Templates are copied to `dist/templates/` by tsdown's `copy` config, so paths now resolve relative to `__dirname` (the `dist/` directory) instead of navigating up to a non-existent `src/` directory.

--- a/packages/cli/src/commands/profile/create.ts
+++ b/packages/cli/src/commands/profile/create.ts
@@ -76,7 +76,7 @@ export const createCommand = defineCommand({
     await mkdir(targetDir, { recursive: true });
 
     // Copy minimal template files
-    const templateDir = join(__dirname, "../src/templates/profile", "minimal");
+    const templateDir = join(__dirname, "templates", "profile", "minimal");
     await copyProfileTemplate(templateDir, targetDir, { name });
 
     p.outro(`Profile '${name}' created in profiles/${name}/`);

--- a/packages/cli/src/commands/source/create.ts
+++ b/packages/cli/src/commands/source/create.ts
@@ -251,7 +251,7 @@ metadata:
     await mkdir(profileDir, { recursive: true });
 
     // Copy minimal profile template
-    const profileTemplateDir = join(__dirname, "..", "src", "templates", "profile", "minimal");
+    const profileTemplateDir = join(__dirname, "templates", "profile", "minimal");
     await copyDirectory(profileTemplateDir, profileDir, { name: "default" });
   }
 


### PR DESCRIPTION
## Summary

- Fix `baton source create` and `baton profile create` failing with `ENOENT` when trying to copy profile templates
- Both commands referenced templates via `../src/templates/` which doesn't exist in the published npm package — only `dist/` is shipped
- Templates are correctly copied to `dist/templates/` by tsdown's `copy` config, so paths now resolve relative to `__dirname` (the `dist/` directory)

## Test plan

- [x] `bun run build` succeeds
- [x] All 996 tests pass
- [x] Verified built output references correct path (`dist/templates/profile/minimal`)
- [x] Smoke tested `baton source create` with the built CLI