### PR TITLE
fix(ci): add explicit permissions to CI workflow

### DIFF
--- a/.changeset/ci-workflow-permissions.md
+++ b/.changeset/ci-workflow-permissions.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/cli": patch
+---
+
+Add explicit `permissions: contents: read` to CI workflow to satisfy GitHub security audit (least-privilege principle)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality Checks


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the CI workflow to resolve the GitHub CodeQL security audit finding (`actions/missing-workflow-permissions`)
- Follows the principle of least privilege — the CI workflow only checks out code and runs build/lint/test steps, so read-only access is sufficient
- The release workflow already had explicit permissions set per job

## Context

GitHub CodeQL flagged `.github/workflows/ci.yml` because it lacked an explicit `permissions` block. Without it, the `GITHUB_TOKEN` inherits the repository/org default, which may be overly permissive.

## Test plan

- [ ] CI workflow runs successfully on this PR with the new permissions