### PR TITLE
docs: reference baton-dx-source profiles across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ baton sync
 | GitHub Copilot | `github-copilot` | Roo | `roo` |
 | Junie | `junie` | Trae | `trae` |
 
+## Official Source Repository
+
+Baton's own configurations are published as [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) — a real-world example of sources and profiles in action:
+
+| Profile | Command | Audience |
+| ------- | ------- | -------- |
+| **maintainer** | `baton init --profile github:baton-dx/baton-dx-source/maintainer` | Contributors to this repo |
+| **creator** | `baton init --profile github:baton-dx/baton-dx-source/creator` | Developers building their own sources and profiles |
+| **consumer** | `baton init --profile github:baton-dx/baton-dx-source/consumer` | Developers using Baton in their projects |
+
 ## Documentation
 
 - [Installation](docs/01-installation.md) — Prerequisites and install methods

--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -19,6 +19,14 @@ baton source connect github:your-org/dx-configs --name my-team
 
 > **Don't have a source yet?** Create one with `baton source create my-configs`.
 > See [Creating Sources](./03-creating-sources.md) for details.
+>
+> **Want AI-assisted Baton usage?** Connect the official Baton source and sync the `consumer` profile:
+>
+> ```bash
+> baton init --profile github:baton-dx/baton-dx-source/consumer
+> ```
+>
+> This gives your AI tools full context about Baton's CLI, sync workflows, and project management.
 
 ## Step 3: Initialize Your Project
 

--- a/docs/03-creating-sources.md
+++ b/docs/03-creating-sources.md
@@ -287,6 +287,42 @@ source: github:my-org/dx-configs@v1.2.0/frontend
 
 ---
 
+## Real-World Example: `baton-dx-source`
+
+Baton's own official source repository [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) is a complete, production-grade example of everything described in this guide. It demonstrates:
+
+- **Multi-audience profiles** — three specialized profiles (`maintainer`, `creator`, `consumer`) plus a shared `base` profile
+- **Profile inheritance** — all three profiles extend `base` via `extends: ["../base"]` to share common Baton knowledge without duplication
+- **Weight-based layering** — `base` at weight 0, child profiles at weight 10
+- **Full AI configuration** — skills, rules, agents, memory, and commands targeting all 14 AI tools
+- **Conventional directory layout** — `profiles/<name>/ai/{skills,rules,agents,memory,commands}/`
+
+```yaml
+# baton.source.yaml (simplified)
+name: baton-dx-source
+version: 0.1.0
+profiles:
+  - name: base
+    path: profiles/base
+  - name: maintainer
+    path: profiles/maintainer
+  - name: creator
+    path: profiles/creator
+  - name: consumer
+    path: profiles/consumer
+```
+
+The `creator` profile is specifically designed for developers building their own sources and profiles. To get AI-assisted guidance while creating your own source:
+
+```bash
+baton init --profile github:baton-dx/baton-dx-source/creator
+baton sync
+```
+
+This gives your AI tools context about profile schemas, merge strategies, tool transformations, and publishing workflows.
+
+---
+
 ## Next Steps
 
 - [Creating Profiles](./04-creating-profiles.md) -- learn how to define profile manifests and configure AI tools.

--- a/docs/04-creating-profiles.md
+++ b/docs/04-creating-profiles.md
@@ -339,6 +339,8 @@ profiles/
     └── baton.profile.yaml
 ```
 
+> **Real-world example:** Baton's own [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) uses this pattern extensively. A `base` profile (weight 0) contains shared knowledge about Baton's 14 AI tools, merge strategies, and terminology. Three specialized profiles — `maintainer`, `creator`, and `consumer` — each extend `base` and add audience-specific skills, rules, agents, and memory files. This avoids duplicating ~120 lines of shared context across profiles.
+
 ---
 
 ## Weight

--- a/docs/05-using-profiles.md
+++ b/docs/05-using-profiles.md
@@ -286,6 +286,27 @@ Overrides are applied after all profiles have been merged, giving the project th
 
 ---
 
+## Official Baton Profiles
+
+Baton provides official profiles via [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) to help you get started:
+
+| Profile | Audience | What you get |
+| ------- | -------- | ------------ |
+| `consumer` | Project developers | CLI reference, sync workflows, troubleshooting skills, project conventions |
+| `creator` | Source/profile authors | Profile schemas, merge strategies, tool transformations, publishing guides |
+| `maintainer` | Baton contributors | Monorepo architecture, adapter development, code quality, release workflows |
+
+To add Baton's consumer profile to your project for AI-assisted guidance on using Baton:
+
+```bash
+baton init --profile github:baton-dx/baton-dx-source/consumer
+baton sync
+```
+
+This gives your AI tools full context about `baton init`, `baton sync`, `baton update`, `baton diff`, and other CLI commands — so they can help you manage your Baton configuration effectively.
+
+---
+
 ## Next Steps
 
 - [Creating Sources](./03-creating-sources.md) -- learn how to build and publish your own source repositories.

--- a/docs/11-contributing.md
+++ b/docs/11-contributing.md
@@ -103,6 +103,29 @@ Open a PR against `main` with:
 - Related issue numbers
 - Testing performed
 
+## AI-Assisted Development
+
+Baton provides an official **maintainer profile** via [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) that gives your AI tools full context about this monorepo's architecture, coding conventions, and development workflows.
+
+```bash
+baton init --profile github:baton-dx/baton-dx-source/maintainer
+baton sync
+```
+
+### What the maintainer profile includes
+
+The maintainer profile includes:
+
+- **Memory** — Full monorepo architecture (agent-paths → core → cli), adapter pattern, CLI commands, release workflow
+- **8 Skills** — `add-adapter`, `add-ide-platform`, `review-code`, `find-dead-code`, `find-redundancy`, `create-pr`, `run-release`, `run-review`
+- **2 Agents** — `code-quality-auditor` (deep analysis), `consolidation-scout` (redundancy detection)
+- **3 Rules** — `general` (commits, testing, async I/O), `coding-style` (TypeScript strict, Biome), `api-conventions` (citty, clack, Zod)
+- **3 Commands** — `/build`, `/quality`, `/verify`
+
+All configurations are automatically transformed and placed for whichever AI tools you use (Claude Code, Cursor, Windsurf, etc.).
+
+---
+
 ## Common Contribution Tasks
 
 ### Adding a New AI Tool Adapter


### PR DESCRIPTION
## Summary

- Adds references to the official [`baton-dx-source`](https://github.com/baton-dx/baton-dx-source) repository and its three profiles (`maintainer`, `creator`, `consumer`) across all relevant documentation files
- Helps users discover the official profiles for AI-assisted Baton usage, source creation, and contributing

## Changes

- **README.md** — Added "Official Source Repository" section with profile table
- **docs/02-quickstart.md** — Added tip about `consumer` profile for AI-assisted usage
- **docs/03-creating-sources.md** — Added real-world example section showing `baton-dx-source` structure
- **docs/04-creating-profiles.md** — Added cross-reference to `baton-dx-source` inheritance pattern
- **docs/05-using-profiles.md** — Added "Official Baton Profiles" section with audience table
- **docs/11-contributing.md** — Added "AI-Assisted Development" section with maintainer profile details

## Test plan

- [ ] Verify all GitHub links to `baton-dx/baton-dx-source` resolve correctly
- [ ] Review documentation renders properly in GitHub markdown
- [ ] Confirm no broken cross-references between docs