### PR TITLE
fix(core): resolve inherited profile local paths during sync

### DIFF
--- a/.changeset/fix-profile-inheritance-sync.md
+++ b/.changeset/fix-profile-inheritance-sync.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/cli": patch
+---
+
+Fix profile inheritance (extends) not working during sync — parent profile content (memory, rules, skills, files, commands) was silently skipped because inherited profiles were not registered in the local path map

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -759,6 +759,14 @@ export const syncCommand = defineCommand({
         }
       }
 
+      // Register local paths for inherited profiles (from extends chains)
+      // These profiles are not in baton.yaml but were resolved via resolveProfileChain
+      for (const prof of allProfiles) {
+        if (!profileLocalPaths.has(prof.name) && prof.localPath) {
+          profileLocalPaths.set(prof.name, prof.localPath);
+        }
+      }
+
       // Content accumulator for files that may receive content from multiple categories
       // (e.g., GitHub Copilot uses .github/copilot-instructions.md for both memory AND rules)
       // Key: absolute target path, Value: { parts, adapter, profiles }

--- a/packages/core/src/inheritance/profile-chain.test.ts
+++ b/packages/core/src/inheritance/profile-chain.test.ts
@@ -393,5 +393,54 @@ extends:
       expect(chain[1].name).toBe("middle");
       expect(chain[2].name).toBe("top");
     });
+
+    it("populates localPath for inherited profiles", async () => {
+      // Create base profile
+      const basePath = join(profilesDir, "base");
+      await mkdir(basePath, { recursive: true });
+      await writeFile(
+        join(basePath, "baton.profile.yaml"),
+        `
+name: base-profile
+version: 1.0.0
+description: Base profile
+`,
+        "utf-8",
+      );
+
+      // Create child profile that extends base
+      const childPath = join(profilesDir, "child");
+      await mkdir(childPath, { recursive: true });
+      await writeFile(
+        join(childPath, "baton.profile.yaml"),
+        `
+name: child-profile
+version: 1.0.0
+description: Child profile
+extends:
+  - ./profiles/base
+`,
+        "utf-8",
+      );
+
+      const childManifest = {
+        name: "child-profile",
+        version: "1.0.0",
+        description: "Child profile",
+        extends: ["./profiles/base"],
+      };
+
+      const chain = await resolveProfileChain(childManifest, "./profiles/child", tempDir);
+
+      expect(chain).toHaveLength(2);
+
+      // Inherited base profile should have localPath resolved
+      expect(chain[0].name).toBe("base-profile");
+      expect(chain[0].localPath).toBe(basePath);
+
+      // Root profile (not loaded via loadProfileFromSource) has no localPath
+      expect(chain[1].name).toBe("child-profile");
+      expect(chain[1].localPath).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/inheritance/profile-chain.ts
+++ b/packages/core/src/inheritance/profile-chain.ts
@@ -20,6 +20,8 @@ export interface ResolvedProfile {
   source: string;
   /** Profile name */
   name: string;
+  /** Resolved local directory path (set for local/file/cloned-git sources) */
+  localPath?: string;
 }
 
 /**
@@ -54,6 +56,7 @@ export async function resolveProfileChain(
  * @param chain - Accumulator for resolved profiles
  * @param visited - Set of visited sources (for circular detection)
  * @param path - Current path (for error messages)
+ * @param localPath - Resolved local directory path for this profile
  */
 async function resolveChainRecursive(
   manifest: ProfileManifest,
@@ -62,6 +65,7 @@ async function resolveChainRecursive(
   chain: ResolvedProfile[],
   visited: Set<string>,
   path: string[],
+  localPath?: string,
 ): Promise<void> {
   // Check for maximum depth
   if (path.length >= MAX_CHAIN_DEPTH) {
@@ -86,12 +90,19 @@ async function resolveChainRecursive(
     for (const extendSource of manifest.extends) {
       try {
         // Load parent profile
-        const parentManifest = await loadProfileFromSource(extendSource, baseDir);
+        const { manifest: parentManifest, localPath: parentLocalPath } =
+          await loadProfileFromSource(extendSource, baseDir);
 
         // Recursively resolve parent chain with current visited set
-        await resolveChainRecursive(parentManifest, extendSource, baseDir, chain, currentVisited, [
-          ...path,
-        ]);
+        await resolveChainRecursive(
+          parentManifest,
+          extendSource,
+          baseDir,
+          chain,
+          currentVisited,
+          [...path],
+          parentLocalPath,
+        );
       } catch (error) {
         // Re-throw critical errors that should not be swallowed
         if (error instanceof CircularInheritanceError) {
@@ -110,6 +121,7 @@ async function resolveChainRecursive(
     manifest,
     source,
     name: manifest.name,
+    localPath,
   });
 
   // Remove from path for sibling processing
@@ -121,9 +133,12 @@ async function resolveChainRecursive(
  *
  * @param source - Source URL or path
  * @param baseDir - Base directory for resolving relative paths
- * @returns Loaded profile manifest
+ * @returns Loaded profile manifest and resolved local directory path
  */
-async function loadProfileFromSource(source: string, baseDir: string): Promise<ProfileManifest> {
+async function loadProfileFromSource(
+  source: string,
+  baseDir: string,
+): Promise<{ manifest: ProfileManifest; localPath: string }> {
   const parsed = parseSource(source);
 
   if (parsed.provider === "local") {
@@ -131,7 +146,7 @@ async function loadProfileFromSource(source: string, baseDir: string): Promise<P
     const absolutePath = resolve(baseDir, parsed.path);
     const manifestPath = resolve(absolutePath, "baton.profile.yaml");
 
-    return await loadProfileManifest(manifestPath);
+    return { manifest: await loadProfileManifest(manifestPath), localPath: absolutePath };
   }
 
   if (parsed.provider === "file") {
@@ -139,7 +154,7 @@ async function loadProfileFromSource(source: string, baseDir: string): Promise<P
     const absolutePath = parsed.path.startsWith("/") ? parsed.path : resolve(baseDir, parsed.path);
     const manifestPath = resolve(absolutePath, "baton.profile.yaml");
 
-    return await loadProfileManifest(manifestPath);
+    return { manifest: await loadProfileManifest(manifestPath), localPath: absolutePath };
   }
 
   if (parsed.provider === "npm") {
@@ -156,5 +171,5 @@ async function loadProfileFromSource(source: string, baseDir: string): Promise<P
   });
 
   const manifestPath = resolve(cloned.localPath, "baton.profile.yaml");
-  return await loadProfileManifest(manifestPath);
+  return { manifest: await loadProfileManifest(manifestPath), localPath: cloned.localPath };
 }


### PR DESCRIPTION
## Summary

- **Bug:** Profile inheritance (`extends: ../base`) was silently broken during `baton sync` — only the directly-referenced child profile was placed, parent content was skipped entirely
- **Root cause:** `profileLocalPaths` in sync.ts only mapped profiles from `baton.yaml`, not inherited profiles resolved via `resolveProfileChain`
- **Fix:** Add `localPath` to `ResolvedProfile` interface so chain resolution preserves resolved directory paths, then register inherited profiles in `profileLocalPaths` during sync

## Changes

| File | Change |
|------|--------|
| `core/src/inheritance/profile-chain.ts` | Add `localPath?: string` to `ResolvedProfile`. Return resolved path from `loadProfileFromSource`. Thread through recursive chain resolution. |
| `cli/src/commands/sync.ts` | Register inherited profiles' local paths after building `profileLocalPaths` from `baton.yaml` entries |
| `core/src/inheritance/profile-chain.test.ts` | Add test verifying `localPath` is populated for inherited profiles |

## Test plan

- [x] All 997 existing tests pass
- [x] New test verifies `localPath` is set for inherited profiles and `undefined` for root
- [x] TypeScript strict typecheck passes
- [x] Biome lint passes
- [ ] Manual: run `baton sync` with a profile that uses `extends` and verify parent content is placed