### PR TITLE
fix(ci): fix release workflow — remove redundant tests, fix Homebrew CI trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,18 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get published version
         id: version
@@ -105,7 +113,7 @@ jobs:
       - name: Create Homebrew PR
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="chore/homebrew-v${VERSION}"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- Remove redundant `bun run test` from release workflow (CI already covers this on push to main)
- Use GitHub App token for Homebrew PR creation so CI workflow triggers

## Problem

1. **Redundant tests**: Release workflow ran tests a second time after CI already passed, causing flaky test failures to block releases
2. **Homebrew PR stuck**: The default `GITHUB_TOKEN` doesn't trigger workflows (GitHub anti-recursion), so the auto-generated Homebrew PR never got CI status — "Quality Checks" stayed pending forever