### PR TITLE
fix(core): extract validateNpmPackageName to fix flaky test

### DIFF
--- a/packages/core/src/sources/npm-resolver.test.ts
+++ b/packages/core/src/sources/npm-resolver.test.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parseSource } from "../utils/source-parser.js";
-import { resolveNpmSource } from "./npm-resolver.js";
+import { resolveNpmSource, validateNpmPackageName } from "./npm-resolver.js";
 
 describe("npm-resolver", () => {
   let testDir: string;
@@ -170,21 +170,12 @@ describe("npm-resolver", () => {
   });
 
   describe("package name validation", () => {
-    it("accepts valid unscoped package names", async () => {
-      const source = parseSource("npm:my-package");
-      if (source.provider !== "npm") throw new Error("Expected npm provider");
-      // Valid name should not throw validation error (will fail on network instead)
-      await expect(resolveNpmSource({ source, basePath: testDir })).rejects.not.toThrow(
-        "Invalid npm package name",
-      );
+    it("accepts valid unscoped package names", () => {
+      expect(() => validateNpmPackageName("my-package")).not.toThrow();
     });
 
-    it("accepts valid scoped package names", async () => {
-      const source = parseSource("npm:@baton-dx/core");
-      if (source.provider !== "npm") throw new Error("Expected npm provider");
-      await expect(resolveNpmSource({ source, basePath: testDir })).rejects.not.toThrow(
-        "Invalid npm package name",
-      );
+    it("accepts valid scoped package names", () => {
+      expect(() => validateNpmPackageName("@baton-dx/core")).not.toThrow();
     });
 
     it("rejects package names with shell metacharacters", async () => {
@@ -217,14 +208,8 @@ describe("npm-resolver", () => {
       ).rejects.toThrow("Invalid npm package name");
     });
 
-    it("accepts package names with version specifier", async () => {
-      const source = {
-        provider: "npm" as const,
-        package: "my-package@1.2.3",
-      };
-      await expect(resolveNpmSource({ source, basePath: testDir })).rejects.not.toThrow(
-        "Invalid npm package name",
-      );
+    it("accepts package names with version specifier", () => {
+      expect(() => validateNpmPackageName("my-package@1.2.3")).not.toThrow();
     });
   });
 

--- a/packages/core/src/sources/npm-resolver.ts
+++ b/packages/core/src/sources/npm-resolver.ts
@@ -15,6 +15,16 @@ const execFileAsync = promisify(execFile);
 const NPM_PACKAGE_NAME_REGEX =
   /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@[^@\s;|&]+)?$/;
 
+/**
+ * Validates an npm package name against the safety regex.
+ * Throws if the name contains invalid characters or shell metacharacters.
+ */
+export function validateNpmPackageName(name: string): void {
+  if (!NPM_PACKAGE_NAME_REGEX.test(name)) {
+    throw new Error(`Invalid npm package name: "${name}"`);
+  }
+}
+
 export interface NpmResolverOptions {
   /**
    * Parsed NPM source (provider: "npm")
@@ -65,9 +75,7 @@ export async function resolveNpmSource(options: NpmResolverOptions): Promise<Res
   const { source, basePath = process.cwd() } = options;
 
   // Validate package name to prevent command injection
-  if (!NPM_PACKAGE_NAME_REGEX.test(source.package)) {
-    throw new Error(`Invalid npm package name: "${source.package}"`);
-  }
+  validateNpmPackageName(source.package);
 
   // Detect package manager from lockfile
   const packageManager = await detectPackageManager(basePath);


### PR DESCRIPTION
## Summary

- Extracted `validateNpmPackageName()` from the inline regex check in `resolveNpmSource()` so validation can be tested without triggering network calls
- Rewrote 3 "accepts" validation tests to call the new function directly — synchronous, no I/O, completes in <1ms
- Kept the 3 "rejects" tests unchanged (they already return fast since validation throws before any network call)

## Test plan

- [x] `bun run test -- packages/core/src/sources/npm-resolver.test.ts` — all 16 non-skipped tests pass in 9ms
- [ ] Verify no regressions in full test suite (`bun run test`)