### PR TITLE
fix(ci): eliminate double-triggered CI and Release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,13 @@ name: Release
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'Formula/**'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-main
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -43,9 +46,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install
-
-      - name: Build all packages
-        run: bun run build
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary

- **CI** was triggering on both `push: main` and `pull_request: main`, causing duplicate runs on every PR merge
- **Release** re-triggered on Homebrew formula PR merges (pure no-ops)
- Release had a redundant standalone `bun run build` step (already handled by `ci:publish`)

## Changes

- Remove `push: branches: [main]` from CI — PRs are the quality gate
- Add concurrency group to CI (`cancel-in-progress: true`) to cancel stale PR runs
- Add `paths-ignore: ['Formula/**']` to Release push trigger — skip Homebrew PR merges
- Remove redundant `bun run build` step from Release — `ci:publish` builds internally
- Use explicit `release-main` concurrency group with `cancel-in-progress: false`

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Feature PR merged | ~3 workflow runs | 2 runs |
| Changeset PR merged | ~2 runs | 1 run |
| Homebrew PR merged | ~2 runs | **0 runs** |

## Test plan

- [ ] Open a PR → CI should trigger once
- [ ] Merge a PR → only Release should run (not CI)
- [ ] `workflow_dispatch` on Release still works (`paths-ignore` only applies to push events)
- [ ] Homebrew-only changes to `Formula/` should not trigger Release