### PR TITLE
Remove dead config list/get/set and unused add/remove functions

### DIFF
--- a/.changeset/remove-dead-config-code.md
+++ b/.changeset/remove-dead-config-code.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/cli": patch
+---
+
+Remove dead `config list/get/set` subcommands and fix misleading help text in `ai-tools list`

--- a/packages/cli/src/commands/ai-tools/list.ts
+++ b/packages/cli/src/commands/ai-tools/list.ts
@@ -135,9 +135,7 @@ export const aiToolsListCommand = defineCommand({
       console.log("");
     }
 
-    p.outro(
-      "Manage tools: 'baton ai-tools scan' (detect) | 'baton config set default-tools <tools>'",
-    );
+    p.outro("Manage tools: 'baton ai-tools scan' (detect) | 'baton ai-tools configure' (select)");
   },
 });
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,11 +1,8 @@
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getAIToolConfig } from "@baton-dx/ai-tool-paths";
 import type { ProjectManifest } from "@baton-dx/core";
 import {
-  getBatonHome,
   getGlobalAiTools,
-  getGlobalConfigPath,
   getGlobalIdePlatforms,
   getGlobalSources,
   loadProjectManifest,
@@ -13,35 +10,8 @@ import {
 } from "@baton-dx/core";
 import * as p from "@clack/prompts";
 import { defineCommand } from "citty";
-import { parse, stringify } from "yaml";
 import { buildIntersection } from "../utils/build-intersection.js";
 import { formatIntersectionSummary } from "../utils/intersection-display.js";
-
-interface BatonConfig {
-  "cache-dir"?: string;
-  "default-scope"?: "project" | "global";
-  "symlink-mode"?: boolean;
-  "default-tools"?: string[];
-}
-
-const VALID_KEYS = ["cache-dir", "default-scope", "symlink-mode", "default-tools"] as const;
-
-async function loadConfig(): Promise<BatonConfig> {
-  const configFile = getGlobalConfigPath();
-  try {
-    await access(configFile);
-  } catch {
-    return {};
-  }
-  const content = await readFile(configFile, "utf-8");
-  return parse(content) as BatonConfig;
-}
-
-async function saveConfig(config: BatonConfig): Promise<void> {
-  const configFile = getGlobalConfigPath();
-  await mkdir(getBatonHome(), { recursive: true });
-  await writeFile(configFile, stringify(config), "utf-8");
-}
 
 async function showDashboard(): Promise<void> {
   p.intro("Baton Dashboard");
@@ -160,7 +130,7 @@ async function showDashboard(): Promise<void> {
   }
 
   console.log("");
-  p.outro("Use 'baton config list' to view configuration settings");
+  p.outro("Manage tools: 'baton ai-tools configure' | 'baton ides configure'");
 }
 
 async function loadProjectManifestSafe(): Promise<ProjectManifest | null> {
@@ -174,132 +144,9 @@ async function loadProjectManifestSafe(): Promise<ProjectManifest | null> {
 export const configCommand = defineCommand({
   meta: {
     name: "config",
-    description: "Show Baton dashboard overview or configure settings (set, get, list)",
+    description: "Show Baton dashboard overview",
   },
-  args: {
-    action: {
-      type: "positional",
-      description: "Action: set, get, or list",
-      required: false,
-    },
-    key: {
-      type: "positional",
-      description: "Configuration key",
-      required: false,
-    },
-    value: {
-      type: "positional",
-      description: "Configuration value (for set)",
-      required: false,
-    },
-  },
-  async run({ args }) {
-    const action = args.action as string | undefined;
-    const key = args.key as string | undefined;
-    const value = args.value as string | undefined;
-
-    // Show dashboard if no action provided
-    if (!action) {
-      await showDashboard();
-      return;
-    }
-
-    const selectedAction = action;
-
-    if (selectedAction === "list") {
-      p.intro("⚙️  Baton Configuration");
-
-      const config = await loadConfig();
-      if (Object.keys(config).length === 0) {
-        p.outro("No configuration set. Using defaults.");
-        return;
-      }
-
-      console.log("");
-      for (const [configKey, configValue] of Object.entries(config)) {
-        console.log(
-          `${configKey}: ${Array.isArray(configValue) ? configValue.join(", ") : configValue}`,
-        );
-      }
-      console.log("");
-
-      p.outro("Configuration loaded");
-      return;
-    }
-
-    if (selectedAction === "get") {
-      if (!key) {
-        p.intro("⚙️  Baton Configuration");
-        p.outro("Error: Missing key argument. Usage: baton config get <key>");
-        process.exit(1);
-      }
-
-      if (!VALID_KEYS.includes(key as (typeof VALID_KEYS)[number])) {
-        p.intro("⚙️  Baton Configuration");
-        p.outro(`Error: Invalid key "${key}". Valid keys: ${VALID_KEYS.join(", ")}`);
-        process.exit(1);
-      }
-
-      const config = await loadConfig();
-      const configValue = config[key as keyof BatonConfig];
-
-      if (configValue === undefined) {
-        p.intro("⚙️  Baton Configuration");
-        p.outro(`"${key}" is not set (using default)`);
-        return;
-      }
-
-      console.log(Array.isArray(configValue) ? configValue.join(", ") : configValue);
-      return;
-    }
-
-    if (selectedAction === "set") {
-      if (!key || !value) {
-        p.intro("⚙️  Baton Configuration");
-        p.outro("Error: Missing arguments. Usage: baton config set <key> <value>");
-        process.exit(1);
-      }
-
-      if (!VALID_KEYS.includes(key as (typeof VALID_KEYS)[number])) {
-        p.intro("⚙️  Baton Configuration");
-        p.outro(`Error: Invalid key "${key}". Valid keys: ${VALID_KEYS.join(", ")}`);
-        process.exit(1);
-      }
-
-      p.intro("⚙️  Baton Configuration");
-
-      const config = await loadConfig();
-
-      // Type-safe value parsing based on key
-      if (key === "default-scope") {
-        if (value !== "project" && value !== "global") {
-          p.outro('Error: default-scope must be either "project" or "global"');
-          process.exit(1);
-        }
-        config["default-scope"] = value;
-      } else if (key === "symlink-mode") {
-        if (value !== "true" && value !== "false") {
-          p.outro('Error: symlink-mode must be either "true" or "false"');
-          process.exit(1);
-        }
-        config["symlink-mode"] = value === "true";
-      } else if (key === "default-tools") {
-        // Parse comma-separated list
-        config["default-tools"] = value.split(",").map((s) => s.trim());
-      } else if (key === "cache-dir") {
-        config["cache-dir"] = value;
-      }
-
-      await saveConfig(config);
-
-      p.outro(
-        `✓ Set ${key} = ${Array.isArray(config[key as keyof BatonConfig]) ? (config[key as keyof BatonConfig] as string[]).join(", ") : config[key as keyof BatonConfig]}`,
-      );
-      return;
-    }
-
-    p.intro("⚙️  Baton Configuration");
-    p.outro(`Error: Unknown action "${selectedAction}". Use: set, get, or list`);
-    process.exit(1);
+  async run() {
+    await showDashboard();
   },
 });

--- a/packages/core/src/config/global-config.test.ts
+++ b/packages/core/src/config/global-config.test.ts
@@ -4,8 +4,6 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ManifestValidationError } from "../errors.js";
 import {
-  addGlobalAiTool,
-  addGlobalIdePlatform,
   addGlobalSource,
   getDefaultGlobalSource,
   getGlobalAiTools,
@@ -13,8 +11,6 @@ import {
   getGlobalIdePlatforms,
   getGlobalSources,
   loadGlobalConfig,
-  removeGlobalAiTool,
-  removeGlobalIdePlatform,
   removeGlobalSource,
   saveGlobalConfig,
   setGlobalAiTools,
@@ -294,43 +290,6 @@ describe("Global Config", () => {
       });
     });
 
-    describe("addGlobalAiTool", () => {
-      it("should add a single tool", async () => {
-        await addGlobalAiTool("claude-code");
-
-        const tools = await getGlobalAiTools();
-        expect(tools).toEqual(["claude-code"]);
-      });
-
-      it("should append to existing tools", async () => {
-        await setGlobalAiTools(["claude-code"]);
-        await addGlobalAiTool("cursor");
-
-        const tools = await getGlobalAiTools();
-        expect(tools).toEqual(["claude-code", "cursor"]);
-      });
-
-      it("should throw when tool already configured", async () => {
-        await addGlobalAiTool("claude-code");
-
-        await expect(addGlobalAiTool("claude-code")).rejects.toThrow(/already configured/);
-      });
-    });
-
-    describe("removeGlobalAiTool", () => {
-      it("should remove a single tool", async () => {
-        await setGlobalAiTools(["claude-code", "cursor"]);
-        await removeGlobalAiTool("claude-code");
-
-        const tools = await getGlobalAiTools();
-        expect(tools).toEqual(["cursor"]);
-      });
-
-      it("should throw when tool not found", async () => {
-        await expect(removeGlobalAiTool("nonexistent")).rejects.toThrow(/not configured/);
-      });
-    });
-
     describe("ai field in globalConfigSchema", () => {
       it("should accept config with ai.tools field", async () => {
         const config = await loadGlobalConfig();
@@ -390,43 +349,6 @@ describe("Global Config", () => {
         expect(config.sources).toHaveLength(1);
         expect(config.ai?.tools).toEqual(["claude-code"]);
         expect(config.ide?.platforms).toEqual(["vscode"]);
-      });
-    });
-
-    describe("addGlobalIdePlatform", () => {
-      it("should add a single platform", async () => {
-        await addGlobalIdePlatform("vscode");
-
-        const platforms = await getGlobalIdePlatforms();
-        expect(platforms).toEqual(["vscode"]);
-      });
-
-      it("should append to existing platforms", async () => {
-        await setGlobalIdePlatforms(["vscode"]);
-        await addGlobalIdePlatform("cursor");
-
-        const platforms = await getGlobalIdePlatforms();
-        expect(platforms).toEqual(["vscode", "cursor"]);
-      });
-
-      it("should throw when platform already configured", async () => {
-        await addGlobalIdePlatform("vscode");
-
-        await expect(addGlobalIdePlatform("vscode")).rejects.toThrow(/already configured/);
-      });
-    });
-
-    describe("removeGlobalIdePlatform", () => {
-      it("should remove a single platform", async () => {
-        await setGlobalIdePlatforms(["vscode", "cursor"]);
-        await removeGlobalIdePlatform("vscode");
-
-        const platforms = await getGlobalIdePlatforms();
-        expect(platforms).toEqual(["cursor"]);
-      });
-
-      it("should throw when platform not found", async () => {
-        await expect(removeGlobalIdePlatform("nonexistent")).rejects.toThrow(/not configured/);
       });
     });
 

--- a/packages/core/src/config/global-config.ts
+++ b/packages/core/src/config/global-config.ts
@@ -205,42 +205,6 @@ export async function setGlobalAiTools(tools: string[]): Promise<void> {
 }
 
 /**
- * Adds a single AI tool to the global configuration.
- *
- * @param toolKey - The tool key to add (e.g., "claude-code")
- * @throws {Error} If the tool is already configured
- */
-export async function addGlobalAiTool(toolKey: string): Promise<void> {
-  const config = await loadGlobalConfig();
-  const currentTools = config.ai?.tools ?? [];
-
-  if (currentTools.includes(toolKey)) {
-    throw new Error(`AI tool "${toolKey}" is already configured`);
-  }
-
-  config.ai = { ...config.ai, tools: [...currentTools, toolKey] };
-  await saveGlobalConfig(config);
-}
-
-/**
- * Removes a single AI tool from the global configuration.
- *
- * @param toolKey - The tool key to remove
- * @throws {Error} If the tool is not found in configuration
- */
-export async function removeGlobalAiTool(toolKey: string): Promise<void> {
-  const config = await loadGlobalConfig();
-  const currentTools = config.ai?.tools ?? [];
-
-  if (!currentTools.includes(toolKey)) {
-    throw new Error(`AI tool "${toolKey}" is not configured`);
-  }
-
-  config.ai = { ...config.ai, tools: currentTools.filter((t) => t !== toolKey) };
-  await saveGlobalConfig(config);
-}
-
-/**
  * Gets the list of persisted IDE platforms from global configuration.
  *
  * @returns Array of platform keys (empty if none configured)
@@ -258,42 +222,6 @@ export async function getGlobalIdePlatforms(): Promise<string[]> {
 export async function setGlobalIdePlatforms(platforms: string[]): Promise<void> {
   const config = await loadGlobalConfig();
   config.ide = { ...config.ide, platforms };
-  await saveGlobalConfig(config);
-}
-
-/**
- * Adds a single IDE platform to the global configuration.
- *
- * @param ideKey - The platform key to add (e.g., "vscode")
- * @throws {Error} If the platform is already configured
- */
-export async function addGlobalIdePlatform(ideKey: string): Promise<void> {
-  const config = await loadGlobalConfig();
-  const currentPlatforms = config.ide?.platforms ?? [];
-
-  if (currentPlatforms.includes(ideKey)) {
-    throw new Error(`IDE platform "${ideKey}" is already configured`);
-  }
-
-  config.ide = { ...config.ide, platforms: [...currentPlatforms, ideKey] };
-  await saveGlobalConfig(config);
-}
-
-/**
- * Removes a single IDE platform from the global configuration.
- *
- * @param ideKey - The platform key to remove
- * @throws {Error} If the platform is not found in configuration
- */
-export async function removeGlobalIdePlatform(ideKey: string): Promise<void> {
-  const config = await loadGlobalConfig();
-  const currentPlatforms = config.ide?.platforms ?? [];
-
-  if (!currentPlatforms.includes(ideKey)) {
-    throw new Error(`IDE platform "${ideKey}" is not configured`);
-  }
-
-  config.ide = { ...config.ide, platforms: currentPlatforms.filter((p) => p !== ideKey) };
   await saveGlobalConfig(config);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -276,12 +276,8 @@ export {
   getGlobalConfigPath,
   getGlobalAiTools,
   setGlobalAiTools,
-  addGlobalAiTool,
-  removeGlobalAiTool,
   getGlobalIdePlatforms,
   setGlobalIdePlatforms,
-  addGlobalIdePlatform,
-  removeGlobalIdePlatform,
 } from "./config/global-config.js";
 
 export type { GlobalSourceEntry } from "./schemas/global-config.js";


### PR DESCRIPTION
## Summary

- Remove `baton config list/get/set` subcommands — used a `BatonConfig` interface with flat keys completely disconnected from the actual `GlobalConfig` schema. Values written via `config set` were never read by any other code path.
- Remove unused `addGlobalAiTool()`, `removeGlobalAiTool()`, `addGlobalIdePlatform()`, `removeGlobalIdePlatform()` from core — only referenced in tests, never called from CLI. The bulk variants (`setGlobalAiTools`, `setGlobalIdePlatforms`) used by `scan` and `configure` commands are sufficient.
- Fix misleading help text in `ai-tools list` that referenced non-functional `baton config set default-tools` — now correctly points to `baton ai-tools configure`.

`baton config` (dashboard) continues to work as before.

## Test plan

- [x] All 1038 tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] Knip dead-code check passes
- [ ] Manual: `baton config` still shows dashboard correctly
- [ ] Manual: `baton ai-tools list` shows corrected help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)