### PR TITLE
feat(cli): add `baton self-update` command

### DIFF
--- a/.changeset/add-self-update.md
+++ b/.changeset/add-self-update.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/cli": minor
+---
+
+feat: add `baton self-update` command for updating Baton to the latest stable version. Auto-detects installation method (npm, pnpm, bun, Homebrew) and runs the appropriate update command.

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  checkLatestVersion,
+  detectInstallMethod,
+  formatInstallCommand,
+  isUpdateAvailable,
+} from "@baton-dx/core";
+import * as p from "@clack/prompts";
+import { defineCommand } from "citty";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function readCurrentVersion(): Promise<string> {
+  try {
+    const pkg = JSON.parse(await readFile(join(__dirname, "../package.json"), "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+export const selfUpdateCommand = defineCommand({
+  meta: {
+    name: "self-update",
+    description: "Update Baton to the latest stable version",
+  },
+  args: {
+    changelog: {
+      type: "boolean",
+      description: "Show release notes for the new version",
+      default: false,
+    },
+    "dry-run": {
+      type: "boolean",
+      description: "Check for updates without performing the update",
+      default: false,
+    },
+    yes: {
+      type: "boolean",
+      alias: "y",
+      description: "Skip confirmation prompt",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    p.intro("baton self-update");
+
+    const currentVersion = await readCurrentVersion();
+
+    // Check latest version
+    const s = p.spinner();
+    s.start("Checking for updates...");
+
+    let latestVersion: string;
+    try {
+      const result = await checkLatestVersion();
+      latestVersion = result.version;
+    } catch (error) {
+      s.stop("Failed to check for updates");
+      p.log.error(error instanceof Error ? error.message : "Unknown error occurred");
+      p.outro("Update check failed.");
+      process.exit(1);
+    }
+
+    s.stop("Version check complete");
+
+    // Compare versions
+    const { updateAvailable } = isUpdateAvailable(currentVersion, latestVersion);
+    if (!updateAvailable) {
+      p.log.success(`Already up to date (v${currentVersion}).`);
+      p.outro("No update needed.");
+      return;
+    }
+
+    // Detect install method
+    const installMethod = await detectInstallMethod();
+    const displayCommand = formatInstallCommand(installMethod);
+
+    p.log.info(
+      [
+        `Current version: v${currentVersion}`,
+        `Latest version:  v${latestVersion}`,
+        installMethod.type !== "unknown" ? `Install method:  ${installMethod.type}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+
+    // Handle unknown install method
+    if (installMethod.type === "unknown") {
+      p.log.warn("Could not detect installation method.");
+      p.log.message(
+        [
+          "Please update manually using one of:",
+          "  npm update -g @baton-dx/cli",
+          "  pnpm update -g @baton-dx/cli",
+          "  bun update -g @baton-dx/cli",
+          "  brew upgrade baton-dx",
+        ].join("\n"),
+      );
+      p.outro("Manual update required.");
+      return;
+    }
+
+    // Dry-run: stop here
+    if (args["dry-run"]) {
+      p.log.info(`Would run: ${displayCommand}`);
+      p.outro("Dry run complete.");
+      return;
+    }
+
+    // Changelog (optional)
+    if (args.changelog) {
+      const changelogUrl = `https://github.com/baton-dx/baton/releases/tag/v${latestVersion}`;
+      p.log.info(`Release notes: ${changelogUrl}`);
+    }
+
+    // Confirmation prompt
+    if (!args.yes) {
+      const confirmed = await p.confirm({
+        message: `Update to v${latestVersion}?`,
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.outro("Update cancelled.");
+        return;
+      }
+    }
+
+    // Execute update
+    const updateSpinner = p.spinner();
+    updateSpinner.start(`Running: ${displayCommand}`);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        execFile(installMethod.bin, installMethod.args, (error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+      updateSpinner.stop(`Successfully updated to v${latestVersion}`);
+      p.outro("Update complete!");
+    } catch (error) {
+      updateSpinner.stop("Update failed");
+      const message = error instanceof Error ? error.message : "Unknown error";
+      p.log.error(`Failed to run: ${displayCommand}`);
+      p.log.error(message);
+      p.outro("Update failed. Please try updating manually.");
+      process.exit(1);
+    }
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { idesCommand } from "./commands/ides/index.js";
 import { initCommand } from "./commands/init.js";
 import { manageCommand } from "./commands/manage.js";
 import { profileCommand } from "./commands/profile/index.js";
+import { selfUpdateCommand } from "./commands/self-update.js";
 import { sourceCommand } from "./commands/source/index.js";
 import { syncCommand } from "./commands/sync.js";
 import { updateCommand } from "./commands/update.js";
@@ -61,6 +62,7 @@ const main = defineCommand({
     profile: profileCommand,
     "ai-tools": aiToolsCommand,
     ides: idesCommand,
+    "self-update": selfUpdateCommand,
   },
   run({ args }) {
     // Show help when no arguments provided
@@ -86,6 +88,9 @@ const main = defineCommand({
       console.log("  profile    Manage profiles (create, list, remove)");
       console.log("  ai-tools   Manage AI tool detection and configuration");
       console.log("  ides       Manage IDE platform detection and configuration");
+      console.log("");
+      console.log("Maintenance:");
+      console.log("  self-update  Update Baton to the latest stable version");
       console.log("");
       console.log("Global Options:");
       console.log("  --help, -h         Show this help message");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -318,3 +318,14 @@ export {
   resolvePreferences,
   type ResolvedPreferences,
 } from "./preferences/index.js";
+
+// Export self-update utilities
+export {
+  detectInstallMethod,
+  formatInstallCommand,
+  checkLatestVersion,
+  isUpdateAvailable,
+  type InstallMethod,
+  type LatestVersionResult,
+  type UpdateCheckResult,
+} from "./self-update/index.js";

--- a/packages/core/src/self-update/check-latest-version.test.ts
+++ b/packages/core/src/self-update/check-latest-version.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkLatestVersion, isUpdateAvailable } from "./check-latest-version.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isUpdateAvailable", () => {
+  it("returns true when latest is newer", () => {
+    const result = isUpdateAvailable("0.5.0", "0.6.0");
+    expect(result).toEqual({
+      currentVersion: "0.5.0",
+      latestVersion: "0.6.0",
+      updateAvailable: true,
+    });
+  });
+
+  it("returns false when versions are equal", () => {
+    const result = isUpdateAvailable("0.5.0", "0.5.0");
+    expect(result).toEqual({
+      currentVersion: "0.5.0",
+      latestVersion: "0.5.0",
+      updateAvailable: false,
+    });
+  });
+
+  it("returns false when current is newer", () => {
+    const result = isUpdateAvailable("1.0.0", "0.9.0");
+    expect(result).toEqual({
+      currentVersion: "1.0.0",
+      latestVersion: "0.9.0",
+      updateAvailable: false,
+    });
+  });
+
+  it("handles prerelease versions", () => {
+    const result = isUpdateAvailable("0.5.0-beta.1", "0.5.0");
+    expect(result.updateAvailable).toBe(true);
+  });
+
+  it("handles major version bumps", () => {
+    const result = isUpdateAvailable("0.99.99", "1.0.0");
+    expect(result.updateAvailable).toBe(true);
+  });
+});
+
+describe("checkLatestVersion", () => {
+  it("fetches and parses the latest version from npm registry", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ version: "1.2.3", description: "Test package" }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await checkLatestVersion();
+    expect(result).toEqual({ version: "1.2.3", description: "Test package" });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on non-ok response", async () => {
+    const mockResponse = { ok: false, status: 404 };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await expect(checkLatestVersion()).rejects.toThrow("npm registry returned 404");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when response has no version field", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ name: "@baton-dx/cli" }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await expect(checkLatestVersion()).rejects.toThrow("Failed to parse version");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when version is not a string", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ version: 123 }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    await expect(checkLatestVersion()).rejects.toThrow("Failed to parse version");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("handles missing description gracefully", async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ version: "2.0.0" }),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await checkLatestVersion();
+    expect(result).toEqual({ version: "2.0.0", description: undefined });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/core/src/self-update/check-latest-version.ts
+++ b/packages/core/src/self-update/check-latest-version.ts
@@ -1,0 +1,59 @@
+import { gt } from "semver";
+import { z } from "zod";
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/@baton-dx/cli/latest";
+
+const npmRegistryResponseSchema = z.object({
+  version: z.string(),
+  description: z.string().optional(),
+});
+
+export interface LatestVersionResult {
+  version: string;
+  description?: string;
+}
+
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+}
+
+/**
+ * Check if a newer version is available by comparing current vs latest.
+ * Uses semver for accurate comparison.
+ */
+export function isUpdateAvailable(
+  currentVersion: string,
+  latestVersion: string,
+): UpdateCheckResult {
+  return {
+    currentVersion,
+    latestVersion,
+    updateAvailable: gt(latestVersion, currentVersion),
+  };
+}
+
+/**
+ * Fetch the latest stable version of @baton-dx/cli from the npm registry.
+ * Uses Node.js native fetch (available since Node 18).
+ */
+export async function checkLatestVersion(): Promise<LatestVersionResult> {
+  const response = await fetch(NPM_REGISTRY_URL, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to check for updates: npm registry returned ${response.status}`);
+  }
+
+  const parsed = npmRegistryResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error("Failed to parse version from npm registry response");
+  }
+
+  return {
+    version: parsed.data.version,
+    description: parsed.data.description,
+  };
+}

--- a/packages/core/src/self-update/detect-install-method.test.ts
+++ b/packages/core/src/self-update/detect-install-method.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from "node:child_process";
+import {
+  type InstallMethod,
+  detectInstallMethod,
+  formatInstallCommand,
+} from "./detect-install-method.js";
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("detectInstallMethod", () => {
+  it("detects Homebrew from Cellar path", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/opt/homebrew/Cellar/baton-dx/0.5.0/bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({
+      type: "homebrew",
+      bin: "brew",
+      args: ["upgrade", "baton-dx"],
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("detects Homebrew from homebrew path", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/usr/local/homebrew/bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({
+      type: "homebrew",
+      bin: "brew",
+      args: ["upgrade", "baton-dx"],
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("detects pnpm from .pnpm path", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [
+        process.argv[0],
+        "/home/user/.local/share/pnpm/node_modules/.pnpm/@baton-dx+cli/bin/baton",
+      ],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({
+      type: "pnpm",
+      bin: "pnpm",
+      args: ["update", "-g", "@baton-dx/cli"],
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("detects bun from .bun path", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/home/user/.bun/install/global/node_modules/.bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({
+      type: "bun",
+      bin: "bun",
+      args: ["update", "-g", "@baton-dx/cli"],
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("detects npm from node_modules path", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/usr/local/lib/node_modules/@baton-dx/cli/bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({
+      type: "npm",
+      bin: "npm",
+      args: ["update", "-g", "@baton-dx/cli"],
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns unknown when path has no recognizable pattern", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/usr/local/bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({ type: "unknown" });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to which when process.argv[1] is empty", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], ""],
+    });
+
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: ExecCallback) => {
+      cb(null, "/opt/homebrew/Cellar/baton-dx/0.5.0/bin/baton\n", "");
+      return {};
+    });
+
+    const result = await detectInstallMethod();
+    expect(result.type).toBe("homebrew");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns unknown when which fails and argv[1] is empty", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], ""],
+    });
+
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: ExecCallback) => {
+      cb(new Error("not found"), "", "");
+      return {};
+    });
+
+    const result = await detectInstallMethod();
+    expect(result).toEqual({ type: "unknown" });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("prioritizes Homebrew over npm when path contains both patterns", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0], "/opt/homebrew/Cellar/baton-dx/node_modules/bin/baton"],
+    });
+
+    const result = await detectInstallMethod();
+    expect(result.type).toBe("homebrew");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("formatInstallCommand", () => {
+  it("formats homebrew command", () => {
+    const method: InstallMethod = { type: "homebrew", bin: "brew", args: ["upgrade", "baton-dx"] };
+    expect(formatInstallCommand(method)).toBe("brew upgrade baton-dx");
+  });
+
+  it("formats npm command", () => {
+    const method: InstallMethod = {
+      type: "npm",
+      bin: "npm",
+      args: ["update", "-g", "@baton-dx/cli"],
+    };
+    expect(formatInstallCommand(method)).toBe("npm update -g @baton-dx/cli");
+  });
+
+  it("returns empty string for unknown", () => {
+    const method: InstallMethod = { type: "unknown" };
+    expect(formatInstallCommand(method)).toBe("");
+  });
+});

--- a/packages/core/src/self-update/detect-install-method.ts
+++ b/packages/core/src/self-update/detect-install-method.ts
@@ -1,0 +1,66 @@
+import { execFile } from "node:child_process";
+
+export type InstallMethod =
+  | { type: "homebrew"; bin: string; args: string[] }
+  | { type: "npm"; bin: string; args: string[] }
+  | { type: "pnpm"; bin: string; args: string[] }
+  | { type: "bun"; bin: string; args: string[] }
+  | { type: "unknown" };
+
+/**
+ * Detect how Baton was installed by analyzing the resolved binary path.
+ * Order matters: Homebrew first (may contain node_modules internally),
+ * then pnpm, bun, npm.
+ */
+export async function detectInstallMethod(): Promise<InstallMethod> {
+  const binPath = await resolveBinaryPath();
+  if (!binPath) {
+    return { type: "unknown" };
+  }
+
+  const normalized = binPath.toLowerCase();
+
+  if (normalized.includes("cellar") || normalized.includes("homebrew")) {
+    return { type: "homebrew", bin: "brew", args: ["upgrade", "baton-dx"] };
+  }
+
+  if (normalized.includes("node_modules/.pnpm") || normalized.includes(".pnpm")) {
+    return { type: "pnpm", bin: "pnpm", args: ["update", "-g", "@baton-dx/cli"] };
+  }
+
+  if (normalized.includes(".bun") || normalized.includes("/bun/")) {
+    return { type: "bun", bin: "bun", args: ["update", "-g", "@baton-dx/cli"] };
+  }
+
+  if (normalized.includes("node_modules") || normalized.includes("npm")) {
+    return { type: "npm", bin: "npm", args: ["update", "-g", "@baton-dx/cli"] };
+  }
+
+  return { type: "unknown" };
+}
+
+/** Format an install method as a human-readable command string. */
+export function formatInstallCommand(method: InstallMethod): string {
+  if (method.type === "unknown") return "";
+  return `${method.bin} ${method.args.join(" ")}`;
+}
+
+async function resolveBinaryPath(): Promise<string | undefined> {
+  // First try process.argv[1] which is the script being executed
+  if (process.argv[1]) {
+    return process.argv[1];
+  }
+
+  // Fallback: use `which` to find the binary
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile("which", ["baton"], (error, out) => {
+        if (error) reject(error);
+        else resolve(out);
+      });
+    });
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/self-update/index.ts
+++ b/packages/core/src/self-update/index.ts
@@ -1,0 +1,12 @@
+export {
+  detectInstallMethod,
+  formatInstallCommand,
+  type InstallMethod,
+} from "./detect-install-method.js";
+
+export {
+  checkLatestVersion,
+  isUpdateAvailable,
+  type LatestVersionResult,
+  type UpdateCheckResult,
+} from "./check-latest-version.js";


### PR DESCRIPTION
## Summary

- Add `baton self-update` command that auto-detects installation method (npm, pnpm, bun, Homebrew) and runs the appropriate update command
- Core logic in `@baton-dx/core` (`detect-install-method`, `check-latest-version`) with CLI presentation in `@baton-dx/cli`
- Supports `--dry-run`, `--changelog`, and `--yes` flags

## Changes

### New files
- `packages/cli/src/commands/self-update.ts` — CLI command using citty + @clack/prompts
- `packages/core/src/self-update/detect-install-method.ts` — Detects install method via binary path analysis
- `packages/core/src/self-update/check-latest-version.ts` — Fetches latest version from npm registry with Zod validation
- `packages/core/src/self-update/index.ts` — Barrel exports
- `packages/core/src/self-update/detect-install-method.test.ts` — 12 tests for install detection
- `packages/core/src/self-update/check-latest-version.test.ts` — 10 tests for version checking

### Modified files
- `packages/cli/src/index.ts` — Register `self-update` subcommand + help text
- `packages/core/src/index.ts` — Export self-update utilities

## Design decisions

- **`execFile` with args array** instead of `execSync` with shell string — avoids shell injection, consistent with existing codebase patterns
- **Zod validation** for npm registry response — follows project convention of "Zod schemas as source of truth"
- **Async `detectInstallMethod`** — follows project convention of async I/O throughout
- **`bin`/`args` separation** in `InstallMethod` type — cleanly separates display string from execution args

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (Biome)
- [x] `bun run test` — all 1098 tests pass (22 new)
- [x] `bun run build` — all packages build successfully
- [ ] Manual test: `bun run dev self-update --dry-run`
- [ ] Manual test: `bun run dev self-update` from Homebrew installation


🤖 Generated with [Claude Code](https://claude.com/claude-code)