### PR TITLE
fix(cli): default sync prompt to "No" on source connect

### DIFF
--- a/.changeset/fix-connect-sync-default.md
+++ b/.changeset/fix-connect-sync-default.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/cli": patch
+---
+
+Default sync prompt to "No" when connecting a new source to prevent accidental global profile sync

--- a/packages/cli/src/commands/source/connect.ts
+++ b/packages/cli/src/commands/source/connect.ts
@@ -60,6 +60,7 @@ export const connectCommand = defineCommand({
 
       const shouldSync = await p.confirm({
         message: "Would you like to sync profiles from this source now?",
+        initialValue: false,
       });
 
       if (p.isCancel(shouldSync) || !shouldSync) {


### PR DESCRIPTION
## Summary
- Sets `initialValue: false` on the sync confirm prompt in `baton source connect`
- Prevents accidental global profile sync when connecting a new source — users must now explicitly opt in

## Test plan
- [ ] Run `baton source connect <url>` and verify the prompt defaults to "No"
- [ ] Press Enter without selecting — should skip sync
- [ ] Select "Yes" — should proceed with sync as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)