### PR TITLE
fix(core): self-update now actually upgrades to latest version

### DIFF
--- a/.changeset/fix-self-update-latest.md
+++ b/.changeset/fix-self-update-latest.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/core": patch
+---
+
+Fix self-update not actually updating to latest version by adding `--latest` flag for bun/pnpm and using `install @latest` for npm

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -95,9 +95,9 @@ export const selfUpdateCommand = defineCommand({
       p.log.message(
         [
           "Please update manually using one of:",
-          "  npm update -g @baton-dx/cli",
-          "  pnpm update -g @baton-dx/cli",
-          "  bun update -g @baton-dx/cli",
+          "  npm install -g @baton-dx/cli@latest",
+          "  pnpm update -g @baton-dx/cli --latest",
+          "  bun update -g @baton-dx/cli --latest",
           "  brew upgrade baton-dx",
         ].join("\n"),
       );

--- a/packages/core/src/self-update/detect-install-method.test.ts
+++ b/packages/core/src/self-update/detect-install-method.test.ts
@@ -69,7 +69,7 @@ describe("detectInstallMethod", () => {
     expect(result).toEqual({
       type: "pnpm",
       bin: "pnpm",
-      args: ["update", "-g", "@baton-dx/cli"],
+      args: ["update", "-g", "@baton-dx/cli", "--latest"],
     });
 
     vi.unstubAllGlobals();
@@ -85,7 +85,7 @@ describe("detectInstallMethod", () => {
     expect(result).toEqual({
       type: "bun",
       bin: "bun",
-      args: ["update", "-g", "@baton-dx/cli"],
+      args: ["update", "-g", "@baton-dx/cli", "--latest"],
     });
 
     vi.unstubAllGlobals();
@@ -101,7 +101,7 @@ describe("detectInstallMethod", () => {
     expect(result).toEqual({
       type: "npm",
       bin: "npm",
-      args: ["update", "-g", "@baton-dx/cli"],
+      args: ["install", "-g", "@baton-dx/cli@latest"],
     });
 
     vi.unstubAllGlobals();
@@ -176,9 +176,9 @@ describe("formatInstallCommand", () => {
     const method: InstallMethod = {
       type: "npm",
       bin: "npm",
-      args: ["update", "-g", "@baton-dx/cli"],
+      args: ["install", "-g", "@baton-dx/cli@latest"],
     };
-    expect(formatInstallCommand(method)).toBe("npm update -g @baton-dx/cli");
+    expect(formatInstallCommand(method)).toBe("npm install -g @baton-dx/cli@latest");
   });
 
   it("returns empty string for unknown", () => {

--- a/packages/core/src/self-update/detect-install-method.ts
+++ b/packages/core/src/self-update/detect-install-method.ts
@@ -25,15 +25,15 @@ export async function detectInstallMethod(): Promise<InstallMethod> {
   }
 
   if (normalized.includes("node_modules/.pnpm") || normalized.includes(".pnpm")) {
-    return { type: "pnpm", bin: "pnpm", args: ["update", "-g", "@baton-dx/cli"] };
+    return { type: "pnpm", bin: "pnpm", args: ["update", "-g", "@baton-dx/cli", "--latest"] };
   }
 
   if (normalized.includes(".bun") || normalized.includes("/bun/")) {
-    return { type: "bun", bin: "bun", args: ["update", "-g", "@baton-dx/cli"] };
+    return { type: "bun", bin: "bun", args: ["update", "-g", "@baton-dx/cli", "--latest"] };
   }
 
   if (normalized.includes("node_modules") || normalized.includes("npm")) {
-    return { type: "npm", bin: "npm", args: ["update", "-g", "@baton-dx/cli"] };
+    return { type: "npm", bin: "npm", args: ["install", "-g", "@baton-dx/cli@latest"] };
   }
 
   return { type: "unknown" };


### PR DESCRIPTION
## Summary
- `baton self-update` reported success but didn't actually install the latest version
- Root cause: `bun/pnpm update -g` without `--latest` only updates within the existing semver range (e.g. `^0.6.0` → `0.6.1`, not `0.7.0`)
- Added `--latest` flag for bun/pnpm, switched npm to `install -g @latest`

## Changes
| Package Manager | Before | After |
|---|---|---|
| **bun** | `bun update -g @baton-dx/cli` | `bun update -g @baton-dx/cli --latest` |
| **pnpm** | `pnpm update -g @baton-dx/cli` | `pnpm update -g @baton-dx/cli --latest` |
| **npm** | `npm update -g @baton-dx/cli` | `npm install -g @baton-dx/cli@latest` |
| **homebrew** | `brew upgrade baton-dx` | *(unchanged — brew always gets latest)* |

## Test plan
- [x] All 12 existing tests updated and passing
- [ ] Manual: `baton self-update --dry-run` shows correct command with `--latest`
- [ ] Manual: `baton self-update` actually updates across minor/major versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)