### PR TITLE
fix(core): remove unused merge field from file config schema

### DIFF
--- a/.changeset/remove-files-merge-field.md
+++ b/.changeset/remove-files-merge-field.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/core": patch
+---
+
+Remove unused `merge` field from file config items in profile manifest schema. Files are deduplicated by target path (last-wins by weight), not merged. Merge strategies only apply to memory items.

--- a/packages/core/src/schemas/profile-manifest.test.ts
+++ b/packages/core/src/schemas/profile-manifest.test.ts
@@ -32,7 +32,7 @@ describe("Schema Validation - Profile Manifest", () => {
           ],
           commands: ["review", "test"],
         },
-        files: [{ source: "biome.json", merge: "deep" }],
+        files: [{ source: "biome.json" }],
         ide: {
           vscode: [".vscode/settings.json"],
           jetbrains: [".idea/settings.xml"],

--- a/packages/core/src/schemas/profile-manifest.ts
+++ b/packages/core/src/schemas/profile-manifest.ts
@@ -82,11 +82,13 @@ const aiSectionSchema = z
 
 /**
  * File configuration item with optional target mapping
+ *
+ * Note: Files are deduplicated by target path (last-wins by weight),
+ * not merged. Merge strategies only apply to memory items.
  */
 const fileConfigItemSchema = z.object({
   source: z.string(), // e.g., "biome.json", "company/policy.md"
   target: z.string().optional(), // Optional target path. If not specified, uses source as target
-  merge: mergeStrategySchema,
 });
 
 /**

--- a/packages/core/src/validation/validate-source.test.ts
+++ b/packages/core/src/validation/validate-source.test.ts
@@ -333,7 +333,7 @@ describe("validateSource", () => {
   it("warns when files/ source is missing", async () => {
     const profileDir = join(TEST_DIR, "profiles", "default");
     await writeProfileManifest(profileDir, {
-      files: [{ source: "biome.json", merge: "deep" }],
+      files: [{ source: "biome.json" }],
     });
     await writeSourceManifest(TEST_DIR, {
       profiles: [{ name: "default", path: "profiles/default" }],
@@ -529,7 +529,7 @@ describe("validateSource", () => {
         memory: [{ source: "MEMORY.md", merge: "append" }],
         commands: ["review"],
       },
-      files: [{ source: "biome.json", merge: "deep" }],
+      files: [{ source: "biome.json" }],
       ide: {
         vscode: ["settings.json"],
       },

--- a/test-fixtures/profiles/team/baton.profile.yaml
+++ b/test-fixtures/profiles/team/baton.profile.yaml
@@ -53,11 +53,8 @@ ai:
 
 files:
   - source: .editorconfig
-    merge: replace
   - source: biome.json
-    merge: deep
   - source: .prettierrc
-    merge: replace
 
 ide:
   vscode:


### PR DESCRIPTION
## Summary

- Remove the unused `merge` field from `fileConfigItemSchema` in the profile manifest schema
- Files are deduplicated by target path (last-wins by weight), not content-merged — the field was never read during placement
- Only memory items legitimately use merge strategies (append, prepend, import, replace)

## Changed files

| File | Change |
|---|---|
| `packages/core/src/schemas/profile-manifest.ts` | Remove `merge` from `fileConfigItemSchema` |
| `packages/core/src/schemas/profile-manifest.test.ts` | Update test fixture |
| `packages/core/src/validation/validate-source.test.ts` | Update 2 test fixtures |
| `test-fixtures/profiles/team/baton.profile.yaml` | Remove `merge` from files section |

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` — all 1135 tests pass
- [ ] Verify existing profile YAMLs with `merge` on files now correctly fail validation (breaking change for profile authors)


🤖 Generated with [Claude Code](https://claude.com/claude-code)