### PR TITLE
fix(core): stop gitignoring project files placed by profiles

### DIFF
--- a/.changeset/remove-files-merge-field.md
+++ b/.changeset/remove-files-merge-field.md
@@ -1,0 +1,7 @@
+---
+"@baton-dx/cli": patch
+"@baton-dx/core": patch
+"@baton-dx/ai-tool-paths": patch
+---
+
+Stop gitignoring project files (e.g. biome.json, .editorconfig) placed by profiles — they should be committed so the project works without Baton.

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -1119,7 +1119,6 @@ export const applyCommand = defineCommand({
       if (!dryRun) {
         await handleGitignoreUpdate({
           projectManifest,
-          fileMap,
           projectRoot,
           spinner,
         });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -188,7 +188,7 @@ export const initCommand = defineCommand({
 
     // If gitignore enabled, write comprehensive patterns for all known tools
     if (gitignoreSetting) {
-      const patterns = collectComprehensivePatterns({ fileTargets: [] });
+      const patterns = collectComprehensivePatterns();
       await updateGitignore(cwd, patterns);
       spinner.stop("✅ Updated .gitignore with managed file patterns");
     } else {

--- a/packages/cli/src/commands/sync-pipeline.ts
+++ b/packages/cli/src/commands/sync-pipeline.ts
@@ -79,11 +79,10 @@ export async function copyDirectoryRecursive(
  */
 export async function handleGitignoreUpdate(params: {
   projectManifest: ProjectManifest;
-  fileMap: Map<string, { source: string; target: string; profileName: string }>;
   projectRoot: string;
   spinner: ReturnType<typeof p.spinner>;
 }): Promise<void> {
-  const { projectManifest, fileMap, projectRoot, spinner } = params;
+  const { projectManifest, projectRoot, spinner } = params;
   const gitignoreEnabled = projectManifest.gitignore !== false;
 
   // Always ensure .baton/ is gitignored
@@ -91,8 +90,7 @@ export async function handleGitignoreUpdate(params: {
 
   if (gitignoreEnabled) {
     spinner.start("Updating .gitignore...");
-    const fileTargets = [...fileMap.values()].map((f) => f.target);
-    const patterns = collectComprehensivePatterns({ fileTargets });
+    const patterns = collectComprehensivePatterns();
     const updated = await updateGitignore(projectRoot, patterns);
     spinner.stop(
       updated ? "Updated .gitignore with managed patterns" : ".gitignore already up to date",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1135,7 +1135,6 @@ export const syncCommand = defineCommand({
       if (!dryRun) {
         await handleGitignoreUpdate({
           projectManifest,
-          fileMap,
           projectRoot,
           spinner,
         });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,6 @@ export {
   updateGitignore,
   type ParsedSource,
   type ParsedFrontmatter,
-  type CollectComprehensivePatternsOptions,
 } from "./utils/index.js";
 
 // Export Git source provider

--- a/packages/core/src/utils/gitignore.test.ts
+++ b/packages/core/src/utils/gitignore.test.ts
@@ -203,7 +203,7 @@ describe("removeGitignoreManagedSection", () => {
 
 describe("collectComprehensivePatterns", () => {
   it("includes patterns for all known AI tools", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     // Claude Code
     expect(result).toContain(".claude/commands/");
     expect(result).toContain(".claude/rules/");
@@ -229,46 +229,45 @@ describe("collectComprehensivePatterns", () => {
   });
 
   it("includes patterns for all known IDE platforms", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     expect(result).toContain(".vscode/");
     expect(result).toContain(".idea/");
   });
 
-  it("includes file targets when provided", () => {
-    const result = collectComprehensivePatterns({
-      fileTargets: ["biome.json", ".editorconfig"],
-    });
-    expect(result).toContain("biome.json");
-    expect(result).toContain(".editorconfig");
+  it("does not include project file targets (they should be committed)", () => {
+    const result = collectComprehensivePatterns();
+    expect(result).not.toContain("biome.json");
+    expect(result).not.toContain(".editorconfig");
+    expect(result).not.toContain(".prettierrc");
   });
 
   it("does not include baton.lock (lockfile should be committed)", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     expect(result).not.toContain("baton.lock");
   });
 
   it("returns sorted, deduplicated patterns", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     const sorted = [...result].sort();
     expect(result).toEqual(sorted);
     expect(result.length).toBe(new Set(result).size);
   });
 
   it("produces stable output across multiple calls", () => {
-    const first = collectComprehensivePatterns({ fileTargets: ["a.json"] });
-    const second = collectComprehensivePatterns({ fileTargets: ["a.json"] });
+    const first = collectComprehensivePatterns();
+    const second = collectComprehensivePatterns();
     expect(first).toEqual(second);
   });
 
   it("deduplicates shared memory files (e.g., AGENTS.md)", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     // Multiple tools share AGENTS.md — should appear only once
     const agentsCount = result.filter((p) => p === "AGENTS.md").length;
     expect(agentsCount).toBe(1);
   });
 
   it("uses full file paths for static adapter paths (not parent directories)", () => {
-    const result = collectComprehensivePatterns({ fileTargets: [] });
+    const result = collectComprehensivePatterns();
     // GitHub Copilot memory/rules are static: .github/copilot-instructions.md
     // Should NOT produce the broad ".github/" pattern
     expect(result).toContain(".github/copilot-instructions.md");

--- a/packages/core/src/utils/gitignore.ts
+++ b/packages/core/src/utils/gitignore.ts
@@ -154,27 +154,19 @@ export async function removeGitignoreManagedSection(projectRoot: string): Promis
 }
 
 /**
- * Parameters for collecting comprehensive gitignore patterns.
- */
-export interface CollectComprehensivePatternsOptions {
-  /** File targets placed by sync (from profile manifests, e.g. "biome.json") */
-  fileTargets: string[];
-}
-
-/**
  * Collect comprehensive gitignore patterns for ALL known AI tools and IDE platforms.
  *
  * Generates patterns for the entire tool and IDE registry, ensuring stable,
  * predictable .gitignore content regardless of which tools a profile supports
  * or a developer has installed.
  *
+ * Note: Project files (from the `files` section in profile manifests) are NOT
+ * gitignored — they should be committed so the project works without Baton.
+ *
  * Returns deduplicated, sorted patterns for AI tool and IDE configurations.
  */
-export function collectComprehensivePatterns(
-  options: CollectComprehensivePatternsOptions,
-): string[] {
+export function collectComprehensivePatterns(): string[] {
   const patterns = new Set<string>();
-  const { fileTargets } = options;
 
   // AI tool patterns: directories, memory files, and legacy paths for ALL known adapters
   const allAdapters = getAllAIToolAdapters();
@@ -207,11 +199,6 @@ export function collectComprehensivePatterns(
       const dir = targetDir.endsWith("/") ? targetDir : `${targetDir}/`;
       patterns.add(dir);
     }
-  }
-
-  // File targets from profiles
-  for (const target of fileTargets) {
-    patterns.add(target);
   }
 
   return [...patterns].sort();

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,5 +6,4 @@ export {
   ensureBatonDirGitignored,
   removeGitignoreManagedSection,
   updateGitignore,
-  type CollectComprehensivePatternsOptions,
 } from "./gitignore.js";


### PR DESCRIPTION
## Summary

- Project files (e.g. `biome.json`, `.editorconfig`, `.prettierrc`) from the `files` section in profile manifests are no longer added to `.gitignore`
- These files should be committed so the project works without Baton installed
- Only AI tool configs (`.claude/`, `.cursor/`, etc.) and IDE configs (`.vscode/`, `.idea/`) remain gitignored

## Changes

- Remove `fileTargets` parameter from `collectComprehensivePatterns()` and the `CollectComprehensivePatternsOptions` interface
- Remove `fileMap` parameter from `handleGitignoreUpdate()`
- Update all callers in `sync.ts`, `apply.ts`, `init.ts`
- Update tests to verify project files are **not** gitignored

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` — all 1135 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)