### PR TITLE
fix(core): fall through to re-clone on transient cache-read failure

### DIFF
--- a/.changeset/fix-enoent-cache-fallthrough.md
+++ b/.changeset/fix-enoent-cache-fallthrough.md
@@ -1,0 +1,5 @@
+---
+"@baton-dx/core": patch
+---
+
+Fix hard failure on transient ENOENT during cached repo read by falling through to re-clone instead of throwing

--- a/packages/core/src/sources/git-clone.test.ts
+++ b/packages/core/src/sources/git-clone.test.ts
@@ -558,6 +558,83 @@ describe("cache cleanup retry (rmRobust)", () => {
     });
 });
 
+describe("cache-hit fallthrough on transient error", () => {
+    const mockRm = vi.mocked(rm);
+    let mockCheckIsRepo: ReturnType<typeof vi.fn>;
+    let mockPull: ReturnType<typeof vi.fn>;
+    let mockRevparse: ReturnType<typeof vi.fn>;
+    let mockClone: ReturnType<typeof vi.fn>;
+    let mockRaw: ReturnType<typeof vi.fn>;
+    let mockCheckout: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        mockCheckIsRepo = vi
+            .fn()
+            .mockResolvedValueOnce(true) // 1st isCacheValid → cache hit
+            .mockRejectedValueOnce(new Error("not a git repo")); // 2nd isCacheValid → cache gone
+        mockPull = vi.fn().mockResolvedValue(undefined);
+        mockRevparse = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("spawn git ENOENT")) // cache-hit revparse fails
+            .mockResolvedValue("abc123def456abc123def456abc123def456abc123"); // fresh clone revparse
+        mockClone = vi.fn().mockResolvedValue(undefined);
+        mockRaw = vi.fn().mockResolvedValue("");
+        mockCheckout = vi.fn().mockResolvedValue(undefined);
+
+        const mockGit = {
+            checkIsRepo: mockCheckIsRepo,
+            pull: mockPull,
+            revparse: mockRevparse,
+            clone: mockClone,
+            raw: mockRaw,
+            checkout: mockCheckout,
+        } as unknown as SimpleGit;
+
+        vi.mocked(gitUtils.createGit).mockReturnValue(mockGit);
+        vi.mocked(gitUtils.createInteractiveGit).mockReturnValue(mockGit);
+        vi.mocked(gitUtils.isAuthError).mockReturnValue(false);
+        mockRm.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("falls through to fresh clone when cache-hit git operation fails with ENOENT", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const result = await cloneGitSource({
+            url: "https://example.com/enoent-cache.git",
+            useCache: true,
+        });
+
+        // Should warn about unusable cache
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Cached repository unusable"));
+        // Should recover via fresh clone
+        expect(result.fromCache).toBe(false);
+        expect(result.sha).toBeDefined();
+        expect(mockClone).toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+    });
+
+    it("still throws GitAuthenticationError on auth failure in cache-hit path", async () => {
+        mockCheckIsRepo.mockReset();
+        mockCheckIsRepo.mockResolvedValueOnce(true);
+
+        mockRevparse.mockReset();
+        mockRevparse.mockRejectedValueOnce(new Error("terminal prompts disabled"));
+        vi.mocked(gitUtils.isAuthError).mockReturnValue(true);
+
+        await expect(
+            cloneGitSource({
+                url: "https://example.com/private-repo.git",
+                useCache: true,
+            }),
+        ).rejects.toThrow(GitAuthenticationError);
+    });
+});
+
 describe("concurrent clone serialization", () => {
     afterEach(() => {
         vi.clearAllMocks();

--- a/packages/core/src/sources/git-clone.ts
+++ b/packages/core/src/sources/git-clone.ts
@@ -210,10 +210,11 @@ async function cloneGitSourceImpl(options: CloneOptions, cachePath: string): Pro
                 sparseCheckout: !!subpath,
             };
         } catch (error) {
-            throw new GitSourceError(
-                `Failed to read cached repository: ${error instanceof Error ? error.message : String(error)}`,
-                error,
-            );
+            if (isAuthError(error)) {
+                throw new GitAuthenticationError(`Authentication required for ${safeUrl}`, error);
+            }
+            // Cache read failed (corrupted cache, missing cwd, transient error) — fall through to re-clone
+            console.warn(`[baton] Cached repository unusable for ${safeUrl}, will re-clone`);
         }
     }
 


### PR DESCRIPTION
## Summary

- Cache-hit catch block in `cloneGitSourceImpl` hard-threw on **any** error, preventing recovery via fetch+reset or fresh clone
- Transient `spawn git ENOENT` (e.g. cache directory removed between validity check and git command) crashed the sync for the first profile from a source
- Now non-auth errors warn and fall through to existing recovery paths, matching the pattern used by all other catch blocks in the function

## Changes

- **`packages/core/src/sources/git-clone.ts`** — Replace hard throw with auth-error check + warn-and-fallthrough
- **`packages/core/src/sources/git-clone.test.ts`** — 2 new tests: ENOENT recovery via fresh clone, auth error still thrown

## Test plan

- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `bun run test -- packages/core/src/sources/git-clone.test.ts` — 22 passed, 9 skipped
- [x] `bun run lint` — no new issues (pre-existing complexity warnings only)